### PR TITLE
Make the search work with BeautifulSoup and beautifulsoup4

### DIFF
--- a/src/collective/base64imagepatch/patch.py
+++ b/src/collective/base64imagepatch/patch.py
@@ -22,18 +22,18 @@ except:
 #    from BeautifulSoup import BeautifulSoup
 
 try:
-    pkg_resources.get_distribution('beautifulsoup4')
-except pkg_resources.DistributionNotFound:
-    pass
-else:
-    from bs4 import BeautifulSoup
-
-try:
     pkg_resources.get_distribution('BeautifulSoup')
 except pkg_resources.DistributionNotFound:
     pass
 else:
     from BeautifulSoup import BeautifulSoup
+
+try:
+    pkg_resources.get_distribution('beautifulsoup4')
+except pkg_resources.DistributionNotFound:
+    pass
+else:
+    from bs4 import BeautifulSoup
 
 ## inner imports
 from collective.base64imagepatch import logger
@@ -165,7 +165,7 @@ def patch(container, obj, name, content):
         )
     soup = BeautifulSoup(content)
 
-    all_images = soup.find_all('img')
+    all_images = soup('img')
     suffix_list = []
     suffix = obj.id + "." + name + ".image"
     for item in container.keys():


### PR DESCRIPTION
Use beautifulsoup4 if both products are installed.
Use the shortcut for find_all() so that BeautifulSoup 3.2.1 also works.
