### PR TITLE
Fixes for dexterity in Plone 4.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 # Packages
 *.egg
 *.egg-info
+.eggs
 dist
 build
 eggs

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,0 +1,8 @@
+[buildout]
+extends = https://raw.githubusercontent.com/collective/buildout.plonetest/master/test-4.x.cfg
+package-name = collective.base64imagepatch
+package-extras = [test]
+
+[versions]
+setuptools = 42.0.1
+zc.buildout = 2.13.4

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 0.13 (unreleased)
 -----------------
 
-- Nothing changed yet.
+- Fixed for Dexterity on Plone 4.3.  [maurits]
 
 
 0.12 (2013-11-05)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 0.13 (unreleased)
 -----------------
 
+- BeautifulSoup: always use lxml.  [maurits]
+
 - Fixed for Dexterity on Plone 4.3.  [maurits]
 
 
@@ -18,9 +20,9 @@ Changelog
 
 - updated setup.py for Homepage and fixed History
 - updated setup.py so that beautifulsoup4 is a dependency that is installed
-- remove soft dependency for BeautifulSoup 3 and usage as beautifulsoup4 could 
+- remove soft dependency for BeautifulSoup 3 and usage as beautifulsoup4 could
   be used in parallel
-- refactor beautifulsoup calls so that it works with all versions of 
+- refactor beautifulsoup calls so that it works with all versions of
   beautifulsoup4 (checked with 4.0.1 4.1.0 4.1.3 4.2.0 4.2.1)
 
 0.10 (2013-07-02)

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 0.13 (unreleased)
 -----------------
 
+- When adding image fails, try the parent container once.  [maurits]
+
 - Fixed patch_all to run patch on objects, not brains.  [maurits]
 
 - BeautifulSoup: always use lxml.  [maurits]

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,8 @@ Changelog
 0.13 (unreleased)
 -----------------
 
+- Fixed patch_all to run patch on objects, not brains.  [maurits]
+
 - BeautifulSoup: always use lxml.  [maurits]
 
 - Fixed for Dexterity on Plone 4.3.  [maurits]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+setuptools==42.0.1
+zc.buildout==2.13.4
+wheel

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import setup
 import os
 
 
-version = '0.13.dev0'
+version = "0.13.dev0"
 
 setup(
-    name='collective.base64imagepatch',
+    name="collective.base64imagepatch",
     version=version,
     description="",
     long_description=open("README.rst").read()
@@ -19,28 +19,28 @@ setup(
         "Framework :: Plone",
         "Programming Language :: Python",
     ],
-    keywords='zope plone base64 image patcher',
-    author='Alexander Loechel',
-    author_email='Alexander.Loechel@lmu.de',
-    url='https://github.com/collective/collective.base64imagepatch',
-    license='GPL',
-    packages=find_packages('src', exclude=['ez_setup']),
-    package_dir={'': 'src'},
-    namespace_packages=['collective'],
+    keywords="zope plone base64 image patcher",
+    author="Alexander Loechel",
+    author_email="Alexander.Loechel@lmu.de",
+    url="https://github.com/collective/collective.base64imagepatch",
+    license="GPL",
+    packages=find_packages("src", exclude=["ez_setup"]),
+    package_dir={"": "src"},
+    namespace_packages=["collective"],
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        'setuptools',
-        'beautifulsoup4',
+        "setuptools",
+        "beautifulsoup4",
     ],
     extras_require={
-        'test': [
-            'Products.PloneTestCase',
-            'plone.app.testing[robot]',
-            'plone.app.robotframework',
-            'Products.ATContentTypes',
-            'Products.contentmigration',
-            'plone.app.contenttypes',
+        "test": [
+            "Products.PloneTestCase",
+            "plone.app.testing[robot]",
+            "plone.app.robotframework",
+            "Products.ATContentTypes",
+            "Products.contentmigration",
+            "plone.app.contenttypes",
         ],
     },
     entry_points="""

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(name='collective.base64imagepatch',
       ],
       extras_require={
           'test': [
+              'Products.PloneTestCase',
               'plone.app.testing[robot]',
               'plone.app.robotframework',
               'Products.ATContentTypes',

--- a/setup.py
+++ b/setup.py
@@ -31,9 +31,6 @@ setup(
     zip_safe=False,
     install_requires=[
         'setuptools',
-        # -*- Extra requirements: -*-
-        #'BeautifulSoup', # old version
-        #'beautifulsoup4', # new version
         'beautifulsoup4',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
+
 import os
+
 
 version = '0.13.dev0'
 

--- a/setup.py
+++ b/setup.py
@@ -6,50 +6,52 @@ import os
 
 version = '0.13.dev0'
 
-setup(name='collective.base64imagepatch',
-      version=version,
-      description="",
-      long_description=open("README.rst").read() + "\n" +
-                       open(os.path.join("docs", "HISTORY.txt")).read(),
-      # Get more strings from
-      # http://pypi.python.org/pypi?:action=list_classifiers
-      classifiers=[
+setup(
+    name='collective.base64imagepatch',
+    version=version,
+    description="",
+    long_description=open("README.rst").read()
+    + "\n"
+    + open(os.path.join("docs", "HISTORY.txt")).read(),
+    # Get more strings from
+    # http://pypi.python.org/pypi?:action=list_classifiers
+    classifiers=[
         "Framework :: Plone",
         "Programming Language :: Python",
+    ],
+    keywords='zope plone base64 image patcher',
+    author='Alexander Loechel',
+    author_email='Alexander.Loechel@lmu.de',
+    url='https://github.com/collective/collective.base64imagepatch',
+    license='GPL',
+    packages=find_packages('src', exclude=['ez_setup']),
+    package_dir={'': 'src'},
+    namespace_packages=['collective'],
+    include_package_data=True,
+    zip_safe=False,
+    install_requires=[
+        'setuptools',
+        # -*- Extra requirements: -*-
+        #'BeautifulSoup', # old version
+        #'beautifulsoup4', # new version
+        'beautifulsoup4',
+    ],
+    extras_require={
+        'test': [
+            'Products.PloneTestCase',
+            'plone.app.testing[robot]',
+            'plone.app.robotframework',
+            'Products.ATContentTypes',
+            'Products.contentmigration',
+            'plone.app.contenttypes',
         ],
-      keywords='zope plone base64 image patcher',
-      author='Alexander Loechel',
-      author_email='Alexander.Loechel@lmu.de',
-      url='https://github.com/collective/collective.base64imagepatch',
-      license='GPL',
-      packages=find_packages('src', exclude=['ez_setup']),
-      package_dir={'': 'src'},
-      namespace_packages=['collective'],
-      include_package_data=True,
-      zip_safe=False,
-      install_requires=[
-          'setuptools',
-          # -*- Extra requirements: -*-
-          #'BeautifulSoup', # old version
-          #'beautifulsoup4', # new version
-          'beautifulsoup4',
-      ],
-      extras_require={
-          'test': [
-              'Products.PloneTestCase',
-              'plone.app.testing[robot]',
-              'plone.app.robotframework',
-              'Products.ATContentTypes',
-              'Products.contentmigration',
-              'plone.app.contenttypes',
-          ],
-      },
-      entry_points="""
+    },
+    entry_points="""
       # -*- Entry points: -*-
 
       [z3c.autoinclude.plugin]
       target = plone
       """,
-      setup_requires=["PasteScript"],
-      paster_plugins=["ZopeSkel"],
-      )
+    setup_requires=["PasteScript"],
+    paster_plugins=["ZopeSkel"],
+)

--- a/src/collective/__init__.py
+++ b/src/collective/__init__.py
@@ -3,4 +3,5 @@ try:
     __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:
     from pkgutil import extend_path
+
     __path__ = extend_path(__path__, __name__)

--- a/src/collective/__init__.py
+++ b/src/collective/__init__.py
@@ -1,6 +1,6 @@
 # See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
 try:
-    __import__('pkg_resources').declare_namespace(__name__)
+    __import__("pkg_resources").declare_namespace(__name__)
 except ImportError:
     from pkgutil import extend_path
 

--- a/src/collective/base64imagepatch/__init__.py
+++ b/src/collective/base64imagepatch/__init__.py
@@ -20,6 +20,7 @@ else:
 
 logger = logging.getLogger('patch_base64images')
 
+
 def initialize(context):
     """
     Initializer called when used as a Zope 2 product.

--- a/src/collective/base64imagepatch/__init__.py
+++ b/src/collective/base64imagepatch/__init__.py
@@ -3,6 +3,7 @@
 import logging
 import pkg_resources
 
+
 try:
     pkg_resources.get_distribution('Products.Archetypes')
 except pkg_resources.DistributionNotFound:
@@ -24,4 +25,3 @@ def initialize(context):
     Initializer called when used as a Zope 2 product.
     """
     pass
-    

--- a/src/collective/base64imagepatch/__init__.py
+++ b/src/collective/base64imagepatch/__init__.py
@@ -5,20 +5,20 @@ import pkg_resources
 
 
 try:
-    pkg_resources.get_distribution('Products.Archetypes')
+    pkg_resources.get_distribution("Products.Archetypes")
 except pkg_resources.DistributionNotFound:
     HAS_ARCHETYPES = False
 else:
     HAS_ARCHETYPES = True
 
 try:
-    pkg_resources.get_distribution('plone.dexterity')
+    pkg_resources.get_distribution("plone.dexterity")
 except pkg_resources.DistributionNotFound:
     HAS_DEXTERITY = False
 else:
     HAS_DEXTERITY = True
 
-logger = logging.getLogger('patch_base64images')
+logger = logging.getLogger("patch_base64images")
 
 
 def initialize(context):

--- a/src/collective/base64imagepatch/patch.py
+++ b/src/collective/base64imagepatch/patch.py
@@ -3,6 +3,7 @@
 ## external imports
 from Acquisition import aq_inner
 from bs4 import BeautifulSoup
+
 ## inner imports
 from collective.base64imagepatch import HAS_ARCHETYPES
 from collective.base64imagepatch import HAS_DEXTERITY
@@ -18,10 +19,10 @@ import zope.interface
 import zope.schema
 
 
-try: 
+try:
     from zope.component.hooks import getSite
 except:
-    from zope.app.component.hooks import getSite 
+    from zope.app.component.hooks import getSite
 
 
 if HAS_ARCHETYPES:
@@ -30,26 +31,26 @@ if HAS_ARCHETYPES:
 if HAS_DEXTERITY:
     from plone.dexterity.interfaces import IDexterityContent
 
-       
+
 def patch_object(obj):
-    
-    logger.debug("Patching Object \"%s\" on path: %s" , \
-        (obj.title, obj.absolute_url() ) )   
-    
+
+    logger.debug("Patching Object \"%s\" on path: %s", (obj.title, obj.absolute_url()))
+
     container = obj.getParentNode()
-    
+
     if container and container.isPrincipiaFolderish:
-        logger.debug( "Object Type is %s" , obj.portal_type)
-        logger.debug( "Object Parent is %s" , container.absolute_url() ) 
-        
+        logger.debug("Object Type is %s", obj.portal_type)
+        logger.debug("Object Parent is %s", container.absolute_url())
+
         if HAS_ARCHETYPES and IBaseContent.providedBy(obj):
             # Archetype Object
             for field in obj.schema.fields():
                 if field.getType() == "Products.Archetypes.Field.TextField":
                     name = field.getName()
-                    logger.debug( 
-                        "Object \"%s\" is a Archetypes Type that has a field: \"%s\" that is a Archetype TextField that could hold HTML" , 
-                        (obj.title, field.getName()) )
+                    logger.debug(
+                        "Object \"%s\" is a Archetypes Type that has a field: \"%s\" that is a Archetype TextField that could hold HTML",
+                        (obj.title, field.getName()),
+                    )
                     field_content = field.getRaw(obj)
                     if "base64" in field_content:
                         new_content = patch(container, obj, name, field_content)
@@ -60,93 +61,83 @@ def patch_object(obj):
             pt = obj.getTypeInfo()
             schema = pt.lookupSchema()
             for name in zope.schema.getFields(schema).keys():
-                logger.debug( "Object Field Name is %s" , name )
-                logger.debug( "Object Field Type is %s" , \
-                    str( type( getattr(obj, name) ).__name__ ) ) 
-                
+                logger.debug("Object Field Name is %s", name)
+                logger.debug(
+                    "Object Field Type is %s", str(type(getattr(obj, name)).__name__)
+                )
+
                 if type(getattr(obj, name)).__name__ == "RichTextValue":
-                    logger.debug( "object %s is a Dexterity Type" , obj.title )  
+                    logger.debug("object %s is a Dexterity Type", obj.title)
                     field_content = getattr(obj, name).raw
                     if "base64" in field_content:
                         new_content = patch(container, obj, name, field_content)
-                        
+
                         getattr(obj, name).__init__(raw=new_content)
         else:
-            logger.debug( 
-                "Unknown Content-Type-Framework for %s" , 
-                obj.absolute_url() 
-                )
-
+            logger.debug("Unknown Content-Type-Framework for %s", obj.absolute_url())
 
 
 def createImage(container, id, mime_type=None, image_data=None):
     ## Base assumtion: An Image Type is avaliable
     portal = getSite()
     portal_types = getToolByName(portal, "portal_types")
-    
+
     if portal_types.Image.meta_type == "Dexterity FTI":
-        ## assumtion: plone.app.contenttypes Image 
+        ## assumtion: plone.app.contenttypes Image
         logger.debug("Images are \"Dexterity FIT\" Types")
-        #from plone.dexterity.utils import createContentInContainer
-        from plone.namedfile.file import NamedBlobImage 
-        #item = createContentInContainer(
-        #    container, 
-        #    "Image", 
-        #    title=id, 
-        #    id=id, 
+        # from plone.dexterity.utils import createContentInContainer
+        from plone.namedfile.file import NamedBlobImage
+
+        # item = createContentInContainer(
+        #    container,
+        #    "Image",
+        #    title=id,
+        #    id=id,
         #    image=image_data
         #    )
-        #return item
+        # return item
 
-        container.invokeFactory(
-                "Image",
-                title=id, 
-                id=id)
+        container.invokeFactory("Image", title=id, id=id)
         item = container[id]
 
-        #pt = item.getTypeInfo()
-        #schema = pt.lookupSchema()
+        # pt = item.getTypeInfo()
+        # schema = pt.lookupSchema()
 
-        ## assumes, that the Image Type has a field image 
+        ## assumes, that the Image Type has a field image
         ## that is a NamedBlobImage
-        item.image = NamedBlobImage(
-            data=image_data,
-            contentType=mime_type,
-            filename=id
-        ) 
+        item.image = NamedBlobImage(data=image_data, contentType=mime_type, filename=id)
 
         return item
 
-    elif portal_types.Image.Metatype() == "ATBlob" or \
-        portal_types.Image.Metatype() == "ATImage":
+    elif (
+        portal_types.Image.Metatype() == "ATBlob"
+        or portal_types.Image.Metatype() == "ATImage"
+    ):
 
         logger.debug("Images are \"Archetypes\" Types")
         container.invokeFactory(
-                "Image", 
-                id=id, 
-                title=id,
-                mime_type=mime_type, 
-                image=image_data
-            )
+            "Image", id=id, title=id, mime_type=mime_type, image=image_data
+        )
         return container[id]
 
     else:
         logger.warn("Unknown Factory or Invocation for Image")
-        logger.warn("Image has Meta-Type: %s" , portal_types.Image.meta_type)
+        logger.warn("Image has Meta-Type: %s", portal_types.Image.meta_type)
     return None
-    
-def patch(container, obj, name, content=""):    
-    """ 
+
+
+def patch(container, obj, name, content=""):
+    """
     Original Patch for both:
-    * Archetypes 
+    * Archetypes
     * Dexterity
     """
     if container != None:
-        counter = 0    
-        logger.debug( \
-            "Patching Object \"%s\" on path: %s field: %s content length = %s", 
-            ( obj.title, obj.absolute_url(), name, str( len(content) ) ) 
-            )
+        counter = 0
+        logger.debug(
+            "Patching Object \"%s\" on path: %s field: %s content length = %s",
+            (obj.title, obj.absolute_url(), name, str(len(content))),
+        )
         base_html_doc = "<html><head></head><body>%s</body></html>" % content
 
         soup = BeautifulSoup(base_html_doc)
@@ -155,52 +146,50 @@ def patch(container, obj, name, content=""):
         suffix_list = []
         suffix = obj.id + "." + name + ".image"
         for item in container.keys():
-            
+
             if item.startswith(suffix):
-                suffix_list.append(int(item[len(suffix):]))
+                suffix_list.append(int(item[len(suffix) :]))
                 counter += 1
         suffix_list.sort()
         counter = max(suffix_list) + 1 if len(suffix_list) > 0 else 0
 
         for img_tag in all_images:
-            if hasattr(img_tag, 'src') and \
-                img_tag['src'].startswith('data') \
-                and 'base64' in img_tag['src'] :
-                
+            if (
+                hasattr(img_tag, 'src')
+                and img_tag['src'].startswith('data')
+                and 'base64' in img_tag['src']
+            ):
+
                 image_params = img_tag['src'].split(';')
-                mime_type = image_params[0][len("data:"):]
+                mime_type = image_params[0][len("data:") :]
                 if mime_type == "":
                     mime_type = None
                 else:
                     logger.debug(
-                        "Found image <img > with mime-type: %s" , 
-                        str(mime_type)
-                        )                
-                img_data = image_params[1][len("base64,"):]
+                        "Found image <img > with mime-type: %s", str(mime_type)
+                    )
+                img_data = image_params[1][len("base64,") :]
                 img_id = suffix + str(counter)
-                   
-                # create File in Container with base-name.image# 
-                #container.invokeFactory(
-                #    "Image", 
-                #    id=img_id, 
-                #    mime_type=mime_type, 
+
+                # create File in Container with base-name.image#
+                # container.invokeFactory(
+                #    "Image",
+                #    id=img_id,
+                #    mime_type=mime_type,
                 #    image=base64.b64decode(img_data))
                 new_image = createImage(
-                    container, 
-                    img_id, 
-                    mime_type, 
-                    base64.b64decode(img_data))
+                    container, img_id, mime_type, base64.b64decode(img_data)
+                )
 
                 ## set src attribute to new src-location
                 ## new_image.relative_url_path() includes Portal-Name
-                ## id is correct, as it is directly in the same container as 
+                ## id is correct, as it is directly in the same container as
                 ## the modified object
-                img_tag['src'] = new_image.id 
+                img_tag['src'] = new_image.id
                 counter += 1
-        
+
         if counter > 0:
             content = "".join(str(n) for n in soup('body', limit=1)[0].contents)
 
-            
         logger.debug("New Content of Object %s:\n%s" % (obj.absolute_url(), content))
     return content

--- a/src/collective/base64imagepatch/patch.py
+++ b/src/collective/base64imagepatch/patch.py
@@ -3,6 +3,10 @@
 ## external imports
 from Acquisition import aq_inner
 from bs4 import BeautifulSoup
+## inner imports
+from collective.base64imagepatch import HAS_ARCHETYPES
+from collective.base64imagepatch import HAS_DEXTERITY
+from collective.base64imagepatch import logger
 from Products.CMFCore.interfaces import IContentish
 from Products.CMFCore.utils import getToolByName
 from zope.component import getMultiAdapter
@@ -13,15 +17,12 @@ import re
 import zope.interface
 import zope.schema
 
+
 try: 
     from zope.component.hooks import getSite
 except:
     from zope.app.component.hooks import getSite 
 
-## inner imports
-from collective.base64imagepatch import logger
-from collective.base64imagepatch import HAS_ARCHETYPES
-from collective.base64imagepatch import HAS_DEXTERITY
 
 if HAS_ARCHETYPES:
     from Products.Archetypes.interfaces.base import IBaseContent
@@ -203,4 +204,3 @@ def patch(container, obj, name, content=""):
             
         logger.debug("New Content of Object %s:\n%s" % (obj.absolute_url(), content))
     return content
-    

--- a/src/collective/base64imagepatch/patch.py
+++ b/src/collective/base64imagepatch/patch.py
@@ -27,7 +27,7 @@ if HAS_DEXTERITY:
 
 def patch_object(obj):
 
-    logger.debug("Patching Object \"%s\" on path: %s", (obj.title, obj.absolute_url()))
+    logger.debug('Patching Object "%s" on path: %s', (obj.title, obj.absolute_url()))
 
     container = obj.getParentNode()
 
@@ -41,7 +41,7 @@ def patch_object(obj):
                 if field.getType() == "Products.Archetypes.Field.TextField":
                     name = field.getName()
                     logger.debug(
-                        "Object \"%s\" is a Archetypes Type that has a field: \"%s\" that is a Archetype TextField that could hold HTML",
+                        'Object "%s" is a Archetypes Type that has a field: "%s" that is a Archetype TextField that could hold HTML',
                         (obj.title, field.getName()),
                     )
                     field_content = field.getRaw(obj)
@@ -107,7 +107,7 @@ def createImage(container, id, mime_type=None, image_data=None):
         or portal_types.Image.Metatype() == "ATImage"
     ):
 
-        logger.debug("Images are \"Archetypes\" Types")
+        logger.debug('Images are "Archetypes" Types')
         container.invokeFactory(
             "Image", id=id, title=id, mime_type=mime_type, image=image_data
         )
@@ -128,7 +128,7 @@ def patch(container, obj, name, content=""):
     if container is not None:
         counter = 0
         logger.debug(
-            "Patching Object \"%s\" on path: %s field: %s content length = %s",
+            'Patching Object "%s" on path: %s field: %s content length = %s',
             (obj.title, obj.absolute_url(), name, str(len(content))),
         )
         base_html_doc = "<html><head></head><body>%s</body></html>" % content
@@ -148,12 +148,12 @@ def patch(container, obj, name, content=""):
 
         for img_tag in all_images:
             if (
-                hasattr(img_tag, 'src')
-                and img_tag['src'].startswith('data')
-                and 'base64' in img_tag['src']
+                hasattr(img_tag, "src")
+                and img_tag["src"].startswith("data")
+                and "base64" in img_tag["src"]
             ):
 
-                image_params = img_tag['src'].split(';')
+                image_params = img_tag["src"].split(";")
                 mime_type = image_params[0][len("data:") :]
                 if mime_type == "":
                     mime_type = None
@@ -178,11 +178,11 @@ def patch(container, obj, name, content=""):
                 # new_image.relative_url_path() includes Portal-Name
                 # id is correct, as it is directly in the same container as
                 # the modified object
-                img_tag['src'] = new_image.id
+                img_tag["src"] = new_image.id
                 counter += 1
 
         if counter > 0:
-            content = "".join(str(n) for n in soup('body', limit=1)[0].contents)
+            content = "".join(str(n) for n in soup("body", limit=1)[0].contents)
 
         logger.debug("New Content of Object %s:\n%s" % (obj.absolute_url(), content))
     return content

--- a/src/collective/base64imagepatch/patch.py
+++ b/src/collective/base64imagepatch/patch.py
@@ -45,12 +45,19 @@ def patch_object(obj):
                     name = field.getName()
                     logger.debug(
                         'Object "%s" is a Archetypes Type that has a field: "%s" that is a Archetype TextField that could hold HTML',
-                        (obj.title, field.getName()),
+                        (obj.title, name),
                     )
                     field_content = field.getRaw(obj)
                     if "base64" in field_content:
+                        path = "/".join(obj.getPhysicalPath())
+                        logger.debug(
+                            "Found inline image in TextField %s of Archetypes object at %s",
+                            name,
+                            path,
+                        )
                         new_content = patch(container, obj, name, field_content)
                         field.getMutator(obj)(new_content)
+                        logger.info("Created image for Archetypes object at %s", path)
 
         elif HAS_DEXTERITY and IDexterityContent.providedBy(obj):
             # Dexterity Object
@@ -64,10 +71,11 @@ def patch_object(obj):
                         continue
                     field_content = attribute.raw
                     if "base64" in field_content:
+                        path = "/".join(obj.getPhysicalPath())
                         logger.debug(
                             "Found inline image in rich text field %s of Dexterity object at %s",
                             name,
-                            "/".join(obj.getPhysicalPath()),
+                            path,
                         )
                         new_content = patch(container, obj, name, field_content)
                         setattr(
@@ -80,9 +88,7 @@ def patch_object(obj):
                                 encoding=attribute.encoding,
                             ),
                         )
-                        logger.debug(
-                            "Created image for object at %s", obj.absolute_url()
-                        )
+                        logger.info("Created image for Dexterity object at %s", path)
 
         else:
             logger.debug("Unknown Content-Type-Framework for %s", obj.absolute_url())

--- a/src/collective/base64imagepatch/patch.py
+++ b/src/collective/base64imagepatch/patch.py
@@ -1,19 +1,12 @@
 # -*- coding: utf-8 -*-
 
-## external imports
-from Acquisition import aq_inner
 from bs4 import BeautifulSoup
-
-## inner imports
 from collective.base64imagepatch import HAS_ARCHETYPES
 from collective.base64imagepatch import HAS_DEXTERITY
 from collective.base64imagepatch import logger
-from Products.CMFCore.interfaces import IContentish
 from Products.CMFCore.utils import getToolByName
-from zope.component import getMultiAdapter
 
 import base64
-import pkg_resources
 import re
 import zope.interface
 import zope.schema
@@ -21,7 +14,7 @@ import zope.schema
 
 try:
     from zope.component.hooks import getSite
-except:
+except ImportError:
     from zope.app.component.hooks import getSite
 
 
@@ -78,13 +71,13 @@ def patch_object(obj):
 
 
 def createImage(container, id, mime_type=None, image_data=None):
-    ## Base assumtion: An Image Type is avaliable
+    # Base assumption: An Image Type is avaliable
     portal = getSite()
     portal_types = getToolByName(portal, "portal_types")
 
     if portal_types.Image.meta_type == "Dexterity FTI":
-        ## assumtion: plone.app.contenttypes Image
-        logger.debug("Images are \"Dexterity FIT\" Types")
+        # assumption: plone.app.contenttypes Image
+        logger.debug("Images are 'Dexterity FTI' Types")
         # from plone.dexterity.utils import createContentInContainer
         from plone.namedfile.file import NamedBlobImage
 
@@ -103,8 +96,8 @@ def createImage(container, id, mime_type=None, image_data=None):
         # pt = item.getTypeInfo()
         # schema = pt.lookupSchema()
 
-        ## assumes, that the Image Type has a field image
-        ## that is a NamedBlobImage
+        # assumes, that the Image Type has a field image
+        # that is a NamedBlobImage
         item.image = NamedBlobImage(data=image_data, contentType=mime_type, filename=id)
 
         return item
@@ -132,7 +125,7 @@ def patch(container, obj, name, content=""):
     * Archetypes
     * Dexterity
     """
-    if container != None:
+    if container is not None:
         counter = 0
         logger.debug(
             "Patching Object \"%s\" on path: %s field: %s content length = %s",
@@ -181,10 +174,10 @@ def patch(container, obj, name, content=""):
                     container, img_id, mime_type, base64.b64decode(img_data)
                 )
 
-                ## set src attribute to new src-location
-                ## new_image.relative_url_path() includes Portal-Name
-                ## id is correct, as it is directly in the same container as
-                ## the modified object
+                # set src attribute to new src-location
+                # new_image.relative_url_path() includes Portal-Name
+                # id is correct, as it is directly in the same container as
+                # the modified object
                 img_tag['src'] = new_image.id
                 counter += 1
 

--- a/src/collective/base64imagepatch/patch.py
+++ b/src/collective/base64imagepatch/patch.py
@@ -156,7 +156,7 @@ def patch(container, obj, name, content=""):
         )
         base_html_doc = "<html><head></head><body>%s</body></html>" % content
 
-        soup = BeautifulSoup(base_html_doc)
+        soup = BeautifulSoup(base_html_doc, features="lxml")
 
         all_images = soup(src=re.compile("(data:).*(;base64,).*"))
         suffix_list = []

--- a/src/collective/base64imagepatch/patch_all_view.py
+++ b/src/collective/base64imagepatch/patch_all_view.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 
 from collective.base64imagepatch import logger
-from collective.base64imagepatch.patch import patch_object  
+from collective.base64imagepatch.patch import patch_object
 from Products.CMFCore.interfaces import IContentish
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser import BrowserView
+
 
 class PatchAllView(BrowserView):
     """
@@ -69,4 +70,3 @@ class PatchAllView(BrowserView):
         logger.info("Finished Patch All\n\n")
 
         return "Finished Patch All"
-     

--- a/src/collective/base64imagepatch/patch_all_view.py
+++ b/src/collective/base64imagepatch/patch_all_view.py
@@ -17,7 +17,7 @@ class PatchAllView(BrowserView):
         Apply patch on all content object on package installation
         """
 
-        catalog = getToolByName(portal, 'portal_catalog')
+        catalog = getToolByName(portal, "portal_catalog")
 
         # query catalog for all content objects that
         # provide IContentish interface

--- a/src/collective/base64imagepatch/patch_all_view.py
+++ b/src/collective/base64imagepatch/patch_all_view.py
@@ -19,11 +19,11 @@ class PatchAllView(BrowserView):
 
         catalog = getToolByName(portal, 'portal_catalog')
 
-        ## query catalog for all content objects that
-        ## provide IContentish interface
+        # query catalog for all content objects that
+        # provide IContentish interface
         all_objects = catalog(object_provides=IContentish.__identifier__)
 
-        ## call patch method for all content objects
+        # call patch method for all content objects
         for obj in all_objects:
             info = "Patch Object: %s at path: %s" % (obj.id, obj.getPath())
             self.request.response.write(info + "\n")

--- a/src/collective/base64imagepatch/patch_all_view.py
+++ b/src/collective/base64imagepatch/patch_all_view.py
@@ -21,14 +21,15 @@ class PatchAllView(BrowserView):
 
         # query catalog for all content objects that
         # provide IContentish interface
-        all_objects = catalog(object_provides=IContentish.__identifier__)
+        all_brains = catalog(object_provides=IContentish.__identifier__)
 
         # call patch method for all content objects
-        for obj in all_objects:
-            info = "Patch Object: %s at path: %s" % (obj.id, obj.getPath())
+        for brain in all_brains:
+            info = "Patch Object: %s at path: %s" % (brain.id, brain.getPath())
             self.request.response.write(info + "\n")
             self.request.response.flush()
             logger.debug(info)
+            obj = brain.getObject()
             patch_object(obj)
 
     def patch_instance(self, portal):

--- a/src/collective/base64imagepatch/patch_all_view.py
+++ b/src/collective/base64imagepatch/patch_all_view.py
@@ -12,41 +12,45 @@ class PatchAllView(BrowserView):
     Patch Browser View for all portals
     """
 
-    def apply_patch_on_plone_instance(self,portal):
-        """ 
-        Apply patch on all content object on package installation 
+    def apply_patch_on_plone_instance(self, portal):
         """
-        
+        Apply patch on all content object on package installation
+        """
+
         catalog = getToolByName(portal, 'portal_catalog')
 
-        ## query catalog for all content objects that 
+        ## query catalog for all content objects that
         ## provide IContentish interface
         all_objects = catalog(object_provides=IContentish.__identifier__)
 
         ## call patch method for all content objects
         for obj in all_objects:
-            info = "Patch Object: %s at path: %s" % (obj.id, obj.getPath() )
+            info = "Patch Object: %s at path: %s" % (obj.id, obj.getPath())
             self.request.response.write(info + "\n")
             self.request.response.flush()
             logger.debug(info)
             patch_object(obj)
 
     def patch_instance(self, portal):
-        info = "Starting patching Plone Instance: %s at path: %s" % \
-            (portal.id, portal.absolute_url() )
+        info = "Starting patching Plone Instance: %s at path: %s" % (
+            portal.id,
+            portal.absolute_url(),
+        )
         self.request.response.write(str(info + "\n"))
         self.request.response.flush()
         logger.info(info)
 
         self.apply_patch_on_plone_instance(portal)
 
-        info = "Finished patching Plone Instance: %s at path: %s\n" % \
-            (portal.id, portal.absolute_url() )
+        info = "Finished patching Plone Instance: %s at path: %s\n" % (
+            portal.id,
+            portal.absolute_url(),
+        )
         self.request.response.write(info + "\n")
         self.request.response.flush()
         logger.info(info)
 
-    def search(self,context):
+    def search(self, context):
         for item in context.values():
             if item.meta_type == "Plone Site":
                 self.patch_instance(item)

--- a/src/collective/base64imagepatch/subscribers.py
+++ b/src/collective/base64imagepatch/subscribers.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from collective.base64imagepatch import logger
-from collective.base64imagepatch.patch import patch_object  
-   
+from collective.base64imagepatch.patch import patch_object
+
+
 def patch_base64_images_on_create(context, event):
     """ 
     Patch created content if it contains an inline images coded as base64 

--- a/src/collective/base64imagepatch/subscribers.py
+++ b/src/collective/base64imagepatch/subscribers.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-
-from collective.base64imagepatch import logger
 from collective.base64imagepatch.patch import patch_object
 
 

--- a/src/collective/base64imagepatch/subscribers.py
+++ b/src/collective/base64imagepatch/subscribers.py
@@ -5,14 +5,14 @@ from collective.base64imagepatch.patch import patch_object
 
 
 def patch_base64_images_on_create(context, event):
-    """ 
-    Patch created content if it contains an inline images coded as base64 
+    """
+    Patch created content if it contains an inline images coded as base64
     """
     patch_object(context)
 
-    
+
 def patch_base64_images_on_modifiy(context, event):
-    """ 
-    Patch created content if it contains an inline images coded as base64 
+    """
+    Patch created content if it contains an inline images coded as base64
     """
     patch_object(context)

--- a/src/collective/base64imagepatch/tests.py
+++ b/src/collective/base64imagepatch/tests.py
@@ -18,11 +18,11 @@ class TestCase(ptc.PloneTestCase):
         @classmethod
         def setUp(cls):
             pass
-            '''
+            """
             fiveconfigure.debug_mode = True
             ztc.installPackage(collective.base64imagepatch)
             fiveconfigure.debug_mode = False
-            '''
+            """
 
         @classmethod
         def tearDown(cls):
@@ -50,5 +50,5 @@ def test_suite():
     )
 
 
-if __name__ == '__main__':
-    unittest.main(defaultTest='test_suite')
+if __name__ == "__main__":
+    unittest.main(defaultTest="test_suite")

--- a/src/collective/base64imagepatch/tests.py
+++ b/src/collective/base64imagepatch/tests.py
@@ -1,8 +1,9 @@
 from Products.Five import fiveconfigure
 from Products.PloneTestCase import PloneTestCase as ptc
 from Products.PloneTestCase.layer import PloneSite
-#from zope.testing import doctestunit
-#from zope.component import testing
+
+# from zope.testing import doctestunit
+# from zope.component import testing
 from Testing import ZopeTestCase as ztc
 
 import collective.base64imagepatch
@@ -12,11 +13,8 @@ import unittest
 ptc.setupPloneSite()
 
 
-
 class TestCase(ptc.PloneTestCase):
-
     class layer(PloneSite):
-
         @classmethod
         def setUp(cls):
             pass
@@ -32,28 +30,25 @@ class TestCase(ptc.PloneTestCase):
 
 
 def test_suite():
-    return unittest.TestSuite([
+    return unittest.TestSuite(
+        [
+            # Unit tests
+            # doctestunit.DocFileSuite(
+            #    'README.txt', package='collective.base64imagepatch',
+            #    setUp=testing.setUp, tearDown=testing.tearDown),
+            # doctestunit.DocTestSuite(
+            #    module='collective.base64imagepatch.mymodule',
+            #    setUp=testing.setUp, tearDown=testing.tearDown),
+            # Integration tests that use PloneTestCase
+            # ztc.ZopeDocFileSuite(
+            #    'README.txt', package='collective.base64imagepatch',
+            #    test_class=TestCase),
+            # ztc.FunctionalDocFileSuite(
+            #    'browser.txt', package='collective.base64imagepatch',
+            #    test_class=TestCase),
+        ]
+    )
 
-        # Unit tests
-        #doctestunit.DocFileSuite(
-        #    'README.txt', package='collective.base64imagepatch',
-        #    setUp=testing.setUp, tearDown=testing.tearDown),
-
-        #doctestunit.DocTestSuite(
-        #    module='collective.base64imagepatch.mymodule',
-        #    setUp=testing.setUp, tearDown=testing.tearDown),
-
-
-        # Integration tests that use PloneTestCase
-        #ztc.ZopeDocFileSuite(
-        #    'README.txt', package='collective.base64imagepatch',
-        #    test_class=TestCase),
-
-        #ztc.FunctionalDocFileSuite(
-        #    'browser.txt', package='collective.base64imagepatch',
-        #    test_class=TestCase),
-
-        ])
 
 if __name__ == '__main__':
     unittest.main(defaultTest='test_suite')

--- a/src/collective/base64imagepatch/tests.py
+++ b/src/collective/base64imagepatch/tests.py
@@ -1,15 +1,16 @@
-import unittest
-
+from Products.Five import fiveconfigure
+from Products.PloneTestCase import PloneTestCase as ptc
+from Products.PloneTestCase.layer import PloneSite
 #from zope.testing import doctestunit
 #from zope.component import testing
 from Testing import ZopeTestCase as ztc
 
-from Products.Five import fiveconfigure
-from Products.PloneTestCase import PloneTestCase as ptc
-from Products.PloneTestCase.layer import PloneSite
+import collective.base64imagepatch
+import unittest
+
+
 ptc.setupPloneSite()
 
-import collective.base64imagepatch
 
 
 class TestCase(ptc.PloneTestCase):


### PR DESCRIPTION
For dexterity in Plone 4.3.20 the current code does not find any fields.  This PR fixes it.
I tried it out in a site with mixed Archetypes and Dexterity items, and it works for both.

As I went along testing this, I made more changes. Most importantly:

- Fixed patch_all to run patch on objects, not brains.
- When adding image fails, try the parent container once. I had inline images in rich text in an FAQ item, and the code tried adding it to the parent FAQ Container, where Images are not allowed. Adding in the container above it worked.

I also added a `requirements.txt` and `buildout.cfg` for Plone 4.3, ran isort and black, and fixed pep8 and pyflakes failures.
This means the git diff is large. Best is to view individual commits.

I could split this up, but may be fine to try it out all together.
